### PR TITLE
Check the node # used for cloud backups/restores

### DIFF
--- a/bin/asl-backup-menu
+++ b/bin/asl-backup-menu
@@ -85,6 +85,12 @@ do_load_asl_settings()
 	return 1
     fi
 
+    # check if backups are support for this node
+    if [[ $NODE -lt 2000 || $NODE =~ ^1.* ]]; then
+	whiptail --msgbox "Backups are not supported for node numbers less than \"2000\" or any node number that starts with \"1\"." $MSGBOX_HEIGHT $MSGBOX_WIDTH
+	return 1
+    fi
+
     return 0
 }
 


### PR DESCRIPTION
Backups (and restores) to "backup.allstarlink.org" should not be enabled/allowed for private nodes (< 2000) or any node that starts with a "1".