### PR TITLE
Remove or Disable Menu Logging

### DIFF
--- a/bin/asl-backup-menu
+++ b/bin/asl-backup-menu
@@ -25,8 +25,7 @@ MSGBOX_HEIGHT=12
 MSGBOX_WIDTH=60
 TITLE="AllStarLink 3.0.0"
 
-#logfile=/dev/null
-logfile=/tmp/asl-backup-menu.log
+logfile=/dev/null
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
 
@@ -505,8 +504,13 @@ do_backup_restore_menu() {
 /usr/bin/clear
 check_if_root
 
-if [[ $# -gt 0 ]]; then
+while [[ $# -gt 0 ]]; do
     case "$1" in
+	"--debug" )
+	    logfile=/tmp/asl-backup-menu.log
+	    shift
+	    ;;
+
 	"backup" )
 	    do_backup
 	    exit $?
@@ -522,21 +526,19 @@ if [[ $# -gt 0 ]]; then
 	    exit $?
 	    ;;
 
-	"delete" | "remove" )
+	"remove" )
 	    do_remove_local
 	    exit $?
 	    ;;
 
 	* )
-	    echo "Usage: $0 [ local | asl ]"
+	    echo "Usage: $0 [ --debug ] [ backup | restore-local | restore-asl | remove ]"
 	    exit 1
     esac
-
-    exit 0
-fi
+done
 
 #
-# ... and w/no args, present the backup/restore menu
+# ... and w/no other args, present the backup/restore menu
 #
 do_backup_restore_menu
 exit $?

--- a/bin/asl-menu
+++ b/bin/asl-menu
@@ -22,8 +22,8 @@ MSGBOX_HEIGHT=12
 MSGBOX_WIDTH=60
 TITLE="AllStarLink 3.0.0"
 
-#logfile=/dev/null
-logfile=/tmp/asl-menu.log
+ASL_DEBUG=""
+logfile=/dev/null
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
 
@@ -137,7 +137,7 @@ do_finish() {
 do_node_setup() {
     echo "do_node_setup" >>$logfile
 
-    /usr/bin/node-setup --sub-menu
+    /usr/bin/node-setup --sub-menu $ASL_DEBUG
 }
 
 do_asterisk_cli() {
@@ -531,7 +531,7 @@ do_sys_diags_menu() {
 do_backup_restore_menu() {
     echo "do_backup_restore_menu" >>$logfile
 
-    /usr/bin/asl-backup-menu
+    /usr/bin/asl-backup-menu $ASL_DEBUG
 }
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
@@ -567,6 +567,20 @@ do_logout_menu() {
 }
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+	"--debug" )
+	    ASL_DEBUG="--debug"
+	    logfile=/tmp/asl-menu.log
+	    shift
+	    ;;
+
+	* )
+	    echo "Usage: $0 [ --debug ]"
+	    exit 1
+    esac
+done
 
 /usr/bin/clear
 check_if_root

--- a/bin/node-setup
+++ b/bin/node-setup
@@ -20,8 +20,8 @@ TITLE="AllStarLink 3.0.0"
 
 SUB_MENU=0
 
-#logfile=/dev/null
-logfile=/tmp/node-setup.log
+ASL_DEBUG=""
+logfile=/dev/null
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
 
@@ -149,7 +149,7 @@ TEMPLATE_CATEGORY_REMOVE() {
 do_backup_restore_menu() {
     echo "do_backup_restore_menu" >>$logfile
 
-    /usr/bin/asl-backup-menu
+    /usr/bin/asl-backup-menu $ASL_DEBUG
 }
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
@@ -1640,13 +1640,19 @@ do_exit() {
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+	"--debug" )
+	    ASL_DEBUG="--debug"
+	    logfile=/tmp/node-setup.log
+	    shift
+	    ;;
+
 	"--sub-menu" )
 	    SUB_MENU=1
 	    shift
 	    ;;
 
 	* )
-	    echo "Usage: $0 [ --sub-menu ]"
+	    echo "Usage: $0 [ --debug ] [ --sub-menu ]"
 	    exit 1
     esac
 done


### PR DESCRIPTION
By default, we will no longer create "log" files for the "asl-menu", "node-setup", and "asl-backup-menu" commands.  But, we have also added a new "--debug" option to the commands that will restore the log files (in "/tmp").