### PR TITLE
Display version number in ASL menus

### DIFF
--- a/bin/asl-backup-menu
+++ b/bin/asl-backup-menu
@@ -15,15 +15,14 @@
 # WD6AWP 03/2021, 04/2021
 # WA3WCO 01/2024
 
+ASL_VERSION=$(asl-show-version --asl)
 BACKUP_DIR="${DESTDIR}/var/asl-backups"
-
-SAVENODE_CONFIG=/etc/asterisk/savenode.conf
-SAVEHOST="backup.allstarlink.org"
-SAVESITE="https://${SAVEHOST}"
-
 MSGBOX_HEIGHT=12
 MSGBOX_WIDTH=60
-TITLE="AllStarLink 3.0.0"
+SAVEHOST="backup.allstarlink.org"
+SAVENODE_CONFIG=/etc/asterisk/savenode.conf
+SAVESITE="https://${SAVEHOST}"
+TITLE="AllStarLink $ASL_VERSION"
 
 logfile=/dev/null
 

--- a/bin/asl-menu
+++ b/bin/asl-menu
@@ -7,22 +7,20 @@
 # Extensive Mods by WD6AWP April & May 2021
 # ASL3 rework/updates by WA3WCO Jan 2024
 
-REBOOT_NEEDED=0
-AST_RESTART=0
-CONFIG_DIR="${DESTDIR}/etc/asterisk"
-
+ASL_DEBUG=""
+ASL_VERSION=$(asl-show-version --asl)
+ASTDN=/usr/bin/astdn.sh
 ASTERISK=/usr/sbin/asterisk
 ASTRES=/usr/bin/astres.sh
 ASTUP=/usr/bin/astup.sh
-ASTDN=/usr/bin/astdn.sh
-
-UPDATE_NODELIST=asl3-update-nodelist
-
+AST_RESTART=0
+CONFIG_DIR=${CONFIG_DIR:-"${DESTDIR}/etc/asterisk"}
 MSGBOX_HEIGHT=12
 MSGBOX_WIDTH=60
-TITLE="AllStarLink 3.0.0"
+REBOOT_NEEDED=0
+TITLE="AllStarLink $ASL_VERSION"
+UPDATE_NODELIST=asl3-update-nodelist
 
-ASL_DEBUG=""
 logfile=/dev/null
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
@@ -72,9 +70,8 @@ calc_wt_size() {
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
 
-get_node_info() {
-    echo "get_node_info" >>$logfile
-
+get_home_info() {
+    echo "get_home_info" >>$logfile
 
     REALID=$(who am i | awk '{print $1}')
     if [ $REALID == "root" ]; then
@@ -181,6 +178,12 @@ do_reboot() {
 	sleep 1
 	/usr/sbin/shutdown -r now
     fi
+}
+
+do_show_version() {
+    echo "do_show_version" >>$logfile
+
+    /usr/bin/asl-show-version --whiptail
 }
 
 do_shutdown() {
@@ -377,10 +380,11 @@ do_main_menu() {
 		    "1" "Node Settings"				\
 		    "2" "Enter a bash shell as root"		\
 		    "3" "Enter the Asterisk CLI"		\
-		    "4" "Diagnostics Menu"			\
-		    "5" "Expert Configuration Menu"		\
-		    "6" "Logout/Reboot/Shutdown"		\
-		    "7" "Enable/disable ASL Menu at login"	\
+		    "4" "Show System Version Numbers"		\
+		    "5" "Diagnostics Menu"			\
+		    "6" "Expert Configuration Menu"		\
+		    "7" "Logout/Reboot/Shutdown"		\
+		    "8" "Enable/disable ASL Menu at login"	\
 		    "B" "Backup and Restore Menu"		\
 		    "I" "Information and help text"		\
 		3>&1 1>&2 2>&3)
@@ -393,10 +397,11 @@ do_main_menu() {
 	    1)	do_node_setup					;;
 	    2)	do_bash_shell					;;
 	    3)	do_asterisk_cli					;;
-	    4)	do_sys_diags_menu				;;
-	    5)	do_conf_edit_menu				;;
-	    6)	do_logout_menu					;;
-	    7)	do_enable_login_menu				;;
+	    4)	do_show_version					;;
+	    5)	do_sys_diags_menu				;;
+	    6)	do_conf_edit_menu				;;
+	    7)	do_logout_menu					;;
+	    8)	do_enable_login_menu				;;
 	    B)	do_backup_restore_menu				;;
 	    I)	info_main_menu					;;
 	    *)	whiptail --msgbox "$ANSWER is an unrecognized selection." $MSGBOX_HEIGHT $MSGBOX_WIDTH ;;
@@ -589,6 +594,6 @@ done
 
 /usr/bin/clear
 check_if_root
-get_node_info
+get_home_info
 check_configuration
 do_main_menu

--- a/bin/asl-show-version
+++ b/bin/asl-show-version
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+ASTERISK=/usr/sbin/asterisk
+ASTERISK_CTL=/var/run/asterisk/asterisk.ctl
+
+if [[ ! -x $ASTERISK ]]; then
+    echo "Asterisk not installed!"
+    exit 1
+fi
+
+if [[ $EUID != 0 && ! -w $ASTERISK_CTL ]]; then
+    echo "This script must be run as root or with sudo"
+    exit 1
+fi
+
+# ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+
+calc_wt_size() {
+    # Bash knows the terminal size
+    #   The number of columns are $COLUMNS
+    #   The number of lines are $LINES
+
+    if [[ $LINES -lt 22 ]]; then
+	echo "Terminal size must be at least 22 lines."
+	exit 1
+    fi
+    if [[ $COLUMNS -lt 60 ]]; then
+	echo "Terminal size must be at least 60 columns."
+	exit 1
+    fi
+
+    WT_HEIGHT=22
+
+    # Leave full width up to 100 columns
+    WT_WIDTH=$COLUMNS
+    if [[ $COLUMNS -gt 100 ]]; then
+	WT_WIDTH=100
+    fi
+
+    WT_MENU_HEIGHT=$(($WT_HEIGHT - 8))
+}
+
+# ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+
+get_asl_version()
+{
+    # get the AllStarLink [app_rpt] version
+    ASL_VER="$($ASTERISK -r -x "rpt show version")"
+    ASL_VER="${ASL_VER#app_rpt version: }"
+}
+
+get_asl_package_info()
+{
+    ASL_PACKAGES=""
+    DEB_PACKAGES=""
+
+    if [ -e /etc/debian_version ]; then
+	# get debian packages
+
+	DEB_PACKAGES=$(
+	    dpkg-query			\
+		--showformat='${db:Status-Abbrev};  ${binary:Package;-20}  ${Version}\n'	\
+		--show			\
+		asl3\*			\
+		allmon3\*		\
+		dahdi\* 		\
+	    | grep -e "^ii"		\
+	    | sed -e 's/^.*;//'		\
+	    | sort
+	)
+    fi
+
+    if [[ -z "$DEB_PACKAGES" ]]; then
+	return
+    fi
+
+    read -r -d '' ASL_PACKAGES << EOT
+Installed ASL packages :
+
+  Package               Version
+  ====================  ==============================
+$DEB_PACKAGES
+EOT
+
+}
+
+get_full_info()
+{
+    # get OS name
+    OS_PRETTY_NAME=$(grep '^PRETTY_NAME\s*=\s*'	/etc/os-release	\
+        | sed 's/^PRETTY_NAME\s*=\s*"//;s/[\s"]*$//')
+
+    # get OS kernel version
+    OS_KERNEL_VER=$(uname -r)
+
+    # get the Asterisk version
+    ASTERISK_VER="$($ASTERISK -V)"
+    ASTERISK_VER="${ASTERISK_VER#Asterisk }"
+
+    # get the AllStarLink version
+    get_asl_version
+
+    # get ASL package info
+    get_asl_package_info
+}
+
+# ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+
+show_asl_version()
+{
+    get_asl_version
+
+    /bin/echo -n "$ASL_VER"
+}
+
+show_full_info()
+{
+    get_full_info
+
+    echo "********** AllStarLink [ASL] Version Info **********"
+
+    echo ""
+    echo "OS            : $OS_PRETTY_NAME"
+    echo "OS Kernel     : $OS_KERNEL_VER"
+
+    echo ""
+    echo "Asterisk      : $ASTERISK_VER"
+    echo "ASL [app_rpt] : $ASL_VER"
+
+    if [[ -n "$ASL_PACKAGES" ]]; then
+	echo ""
+	echo "$ASL_PACKAGES"
+    fi
+}
+
+show_whiptail_info()
+{
+    get_full_info
+
+    read -r -d '' text << EOT
+
+OS            : $OS_PRETTY_NAME
+OS Kernel     : $OS_KERNEL_VER
+
+Asterisk      : $ASTERISK_VER
+ASL [app_rpt] : $ASL_VER
+
+$ASL_PACKAGES
+EOT
+
+    /usr/bin/clear
+    calc_wt_size
+    whiptail						\
+	--title "AllStarLink [ASL] Version Info"	\
+	--scrolltext					\
+	--msgbox "$text"				\
+	$WT_HEIGHT $WT_WIDTH
+
+}
+
+# ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====
+
+if [[ $# -gt 0 ]]; then
+    case "$1" in
+	"--asl" )
+	    show_asl_version
+	    exit $?
+	    ;;
+
+	"--whiptail" )
+	    show_whiptail_info
+	    exit $?
+	    ;;
+
+	* )
+	    echo "Usage: $0 [ --asl | --whiptail ]"
+	    exit 1
+    esac
+
+    exit 0
+fi
+
+#
+# ... and w/no args, report full version info
+#
+show_full_info
+exit $?
+

--- a/bin/node-setup
+++ b/bin/node-setup
@@ -7,23 +7,20 @@
 # Major rework by WD6AWP April 2021
 # ASL3 rework/updates by WA3WCO Jan/Feb 2024
 
+ALLMON3_INI="${DESTDIR}/etc/allmon3/allmon3.ini"
+ALLMON3_RESTART=0
+ASL_DEBUG=""
+ASL_VERSION=$(asl-show-version --asl)
+ASTERISK=/usr/sbin/asterisk
+ASTRES=/usr/bin/astres.sh
 AST_RECONFIG=0
 AST_RESTART=0
 CONFIG_DIR=${CONFIG_DIR:-"${DESTDIR}/etc/asterisk"}
-
-ASTERISK=/usr/sbin/asterisk
-ASTRES=/usr/bin/astres.sh
-
-ALLMON3_INI="${DESTDIR}/etc/allmon3/allmon3.ini"
-ALLMON3_RESTART=0
-
 MSGBOX_HEIGHT=12
 MSGBOX_WIDTH=60
-TITLE="AllStarLink 3.0.0"
-
 SUB_MENU=0
+TITLE="AllStarLink $ASL_VERSION"
 
-ASL_DEBUG=""
 logfile=/dev/null
 
 # ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== ===== =====


### PR DESCRIPTION
* Add "asl-show-version" script (to report OS info, Asterisk and ASL [app_rpt] version, and info on installed ASL packages.
* Add ASL [app_rpt] version number to the "asl-menu", "node-setup", and "asl-backup-menu" displays.
* Add a "Show System Version Numbers" option to the ASL menu.