### PR TITLE
node-setup : specify "node" when exec'ing "tune" menus

### DIFF
--- a/bin/node-setup
+++ b/bin/node-setup
@@ -1800,7 +1800,7 @@ do_interface_tune_cli() {
     case "$CURRENT_INTERFACE_TYPE" in
 	"SimpleUSB" )
 	    clear
-	    /usr/sbin/simpleusb-tune-menu
+	    /usr/sbin/simpleusb-tune-menu -n $CURRENT_NODE
 	    RC=$?
 	    clear
 	    if [[ $RC -ne 0 ]]; then
@@ -1812,7 +1812,7 @@ do_interface_tune_cli() {
 	    ;;
 	"USBRadio" )
 	    clear
-	    /usr/sbin/radio-tune-menu
+	    /usr/sbin/radio-tune-menu -n $CURRENT_NODE
 	    RC=$?
 	    clear
 	    if [[ $RC -ne 0 ]]; then


### PR DESCRIPTION
A change was made to the "simpleusb-tune-menu" and "radio-tune-menu" commands that allows the "node" number to display/update to be specified as a command line argument.

Here, we change the "node-setup" command to specify this new argument when using the "Interface Tune CLI" menu option.  This will help to ensure that any setting updates will be made to the already selected node.