### PR TITLE
Only change IAX port for local nodes

### DIFF
--- a/bin/node-setup
+++ b/bin/node-setup
@@ -538,7 +538,7 @@ do_set_iax_bindport() {
 	    # update the per-node bindport
 	    sed -i					\
 		-E					\
-		-e "/^[0-9]+\s*=\s*radio@/		\
+		-e "/^$CURRENT_NODE\s*=\s*radio@/	\
 			{				\
 			    s/:[0-9]+\//\//;		\
 			    s/\//:$NEW_BINDPORT\//;	\


### PR DESCRIPTION
When updating the IAX port number, ensure that "node-setup" only changes the port number for local nodes.  The IAX port for other nodes listed in [nodes] should be left alone.