### PR TITLE
asl-show-version: don't complain about missing packages

### DIFF
--- a/bin/asl-show-version
+++ b/bin/asl-show-version
@@ -77,6 +77,7 @@ get_asl_package_info()
 		dahdi\* 		\
 		allmon3\*		\
 		cockpit\* 		\
+	    2>/dev/null			\
 	    | grep -e "^ii"		\
 	    | sed -e 's/^.*;//'		\
 	    | sort


### PR DESCRIPTION
The `asl-show-version` command includes unneeded/unwanted output on an "amd64" system if some of the packages we check for are not installed. There is no need to highlight the missing packages.