### PR TITLE
Hide node password

### DIFF
--- a/bin/node-setup
+++ b/bin/node-setup
@@ -1872,13 +1872,14 @@ do_allstar_node_setup_menu() {
 	    DISPLAY_CALLSIGN="*** Not Set ***     <--"
 	fi
 
-	DISPLAY_PASSWORD="$CURRENT_PASSWORD"
 	if [[ "$CURRENT_PASSWORD" = "=Not Set=" ]]; then
 	    if [[ $CURRENT_NODE -ge 2000 ]]; then
 		DISPLAY_PASSWORD="*** Not Set ***     <--"
 	    else
 		DISPLAY_PASSWORD=""
 	    fi
+	else
+	    DISPLAY_PASSWORD="Show/Update"
 	fi
 
 	DISPLAY_TUNE=""


### PR DESCRIPTION
When using the "AllStar Node Setup Menu" and looking at the node settings we were showing the clear-text password for the node.  While the password is readily available in the `rpt_http_registrations.conf` file we don't need to have it always visible.  This visibility has been problematic for those producing videos (including podcasts) that show off using the ASL menus.

This change will now "hide" the passord unless you choose "Show/Update" from the menu options.