### PR TITLE
usbradio.conf: do not default to inverted PTT

### DIFF
--- a/bin/node-setup
+++ b/bin/node-setup
@@ -1301,7 +1301,7 @@ rxlpf = 0\\
 rxhpf = 0\\
 txlpf = 0\\
 txhpf = 0\\
-invertptt = yes\\
+invertptt = no\\
 duplex = 0\\
 duplex3 = 0\\
 \\


### PR DESCRIPTION
With https://github.com/AllStarLink/app_rpt/pull/489, we reverted a "usbradio.conf" change. This change ensures that `node-setup` creates new nodes with the same settings.