### PR TITLE
node-setup: Allow first node to be "1999"

### DIFF
--- a/bin/node-setup
+++ b/bin/node-setup
@@ -582,6 +582,8 @@ do_query_node_number() {
 	    whiptail --msgbox "Private node numbers start at 1000." $MSGBOX_HEIGHT $MSGBOX_WIDTH
 	elif [[ $ANSWER -ge 2000 && $ANSWER =~ ^1 ]]; then
 	    whiptail --msgbox "Registered node numbers cannot start with a \"1\"." $MSGBOX_HEIGHT $MSGBOX_WIDTH
+	elif [[ "$1" = "first" && $ANSWER = $CURRENT_NODE ]]; then
+	    break
 	elif [[ ${nodes[@]} =~ $ANSWER ]]; then
 	    whiptail --msgbox "Node number \"$ANSWER\" is already defined, please choose another." $MSGBOX_HEIGHT $MSGBOX_WIDTH
 	else


### PR DESCRIPTION
When setting up the first node you are prompted for the initial node number. We change the node included in the base configuration (1999) to the requested node. The gotcha is that we had been checking to ensure that the newly requested node number had not already been configured (you don't want two nodes with the same number). This check blocked anyone from trying to set the initial node number to "1999". This change allows any valid node number to be specified.