### PR TITLE
Ensure that the "asterisk" login exists

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -20,6 +20,15 @@ set -e
 do_configure() {
     set +e	# ignore errors temporarily
 
+    # add asterisk user
+    if ! getent passwd asterisk > /dev/null ; then
+        adduser --system --group --quiet	\
+            --home /var/lib/asterisk		\
+            --no-create-home --disabled-login	\
+            --comment "Asterisk PBX daemon"	\
+            asterisk
+    fi
+
     # Set top-level custom dir ownership
     if [ -d /etc/asterisk/custom ]; then
         chown asterisk: /etc/asterisk/custom


### PR DESCRIPTION
The "postinst" script wants to change the ownership of the installed configuration files.  To make this change we need to ensure that the target user ("asterisk") exists.